### PR TITLE
Drop PyUtilib Dependency in pao

### DIFF
--- a/pao/common/shellcmd.py
+++ b/pao/common/shellcmd.py
@@ -4,15 +4,27 @@ import subprocess
 import io
 
 from pyomo.common.collections import Bunch
-from pyutilib.subprocess import run_command
-
+from pyomo.common.tee import TeeStream
 
 
 def run_shellcmd(cmd, *, env=None, tee=False, time_limit=None):
     ostr = io.StringIO()
-    rc, log = run_command(cmd, tee=tee, env=env, timelimit=time_limit,
-            stdout=ostr,
-            stderr=ostr)
+    if not tee:
+        rc, log = subprocess.run(cmd, env=env, timeout=time_limit,
+                stdout=ostr,
+                stderr=ostr)
+    else:
+        with TeeStream(*ostr) as t:
+            results = subprocess.run(
+                cmd,
+                env=env,
+                stdout=t.STDOUT,
+                stderr=t.STDERR,
+                timeout=time_limit,
+                universal_newlines=True,
+            )
+        rc = results.returncode
+        log = ostr[0].getvalue()
 
     return Bunch(rc=rc, log=ostr.getvalue())
 

--- a/pao/common/shellcmd.py
+++ b/pao/common/shellcmd.py
@@ -3,7 +3,7 @@ import sys
 import subprocess
 import io
 
-from pyutilib.misc import Bunch
+from pyomo.common.collections import Bunch
 from pyutilib.subprocess import run_command
 
 

--- a/pao/common/solver.py
+++ b/pao/common/solver.py
@@ -9,7 +9,7 @@ import enum
 import textwrap
 import logging
 
-from pyomo.common.collections import Options
+from pyomo.common.collections import Bunch
 
 import pyomo.opt.parallel.manager
 import pyomo.environ as pe
@@ -370,11 +370,11 @@ class ResultsBase(abc.ABC):
 
     def __init__(self):
         self.solution_manager = None
-        self.solver = Options(
+        self.solver = Bunch(
                 termination_condition=TerminationCondition.unknown,
                 best_feasible_objective=None,
                 )
-        self.problem = Options()
+        self.problem = Bunch()
 
     @abc.abstractmethod
     def found_feasible_solution(self):

--- a/pao/common/solver.py
+++ b/pao/common/solver.py
@@ -9,7 +9,7 @@ import enum
 import textwrap
 import logging
 
-from pyutilib.misc import Options
+from pyomo.common.collections import Options
 
 import pyomo.opt.parallel.manager
 import pyomo.environ as pe
@@ -245,7 +245,7 @@ class SolverAPI(abc.ABC):
         for k,v in config_options.items():
             if k in config:
                 config[k] = v
-                keys.remove(k)    
+                keys.remove(k)
         if validate_options:
             assert (len(keys) == 0), "Unexpected options to solve() have been specified: %s" % " ".join(sorted(k for k in keys))
         return {key:config_options[key] for key in keys}
@@ -331,7 +331,7 @@ class NEOSSolver(SolverAPI):
             return results
         except pyomo.opt.parallel.manager.ActionManagerError as err:
             raise RuntimeError(str(err)) from None
-        
+
 
 """
 >>> opt = Solver('my_solver')
@@ -464,7 +464,7 @@ class SolverFactory(object):
     """
     A class that manages a registry of solvers.
 
-    A solver factory manages a registry that enables 
+    A solver factory manages a registry that enables
     solvers to be created by name.
     """
 
@@ -487,7 +487,7 @@ class SolverFactory(object):
         Returns
         -------
         decorator
-            If the **cls** parameter is None, then a class 
+            If the **cls** parameter is None, then a class
             decorator function
             is returned that can be used to register a solver.
         """

--- a/pao/common/tests/test_solver.py
+++ b/pao/common/tests/test_solver.py
@@ -1,5 +1,5 @@
 import math
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 import pyomo.environ as pe
 
 from pao import Solver
@@ -121,7 +121,7 @@ class Test_neos(unittest.TestCase):
         opt = Solver('cbc', server='neos', email='pao@gmail.com')
         self.assertTrue(opt.available())
         res = opt.solve(M, tee=True)
-        
+
         self.assertTrue(math.isclose(M.x.value, 1, abs_tol=1e-6))
         self.assertTrue(math.isclose(M.y.value, 0, abs_tol=1e-6))
 
@@ -131,7 +131,7 @@ class Test_neos(unittest.TestCase):
         opt = Solver('cbc', server='neos', email='pao@gmail.com', foo=1, bar=None)
         self.assertTrue(opt.available())
         res = opt.solve(M)
-        
+
         self.assertTrue(math.isclose(M.x.value, 1, abs_tol=1e-6))
         self.assertTrue(math.isclose(M.y.value, 0, abs_tol=1e-6))
 

--- a/pao/duality/collect.py
+++ b/pao/duality/collect.py
@@ -23,7 +23,7 @@ __all__ = ("create_linear_dual_from",)
 #pylint: disable-msg=too-many-branches
 #pylint: disable-msg=too-many-statements
 
-from pyutilib.misc import Bunch
+from pyomo.common.collections import Bunch
 from pyomo.repn import generate_standard_repn
 from pyomo.core import (Var,
                         Constraint,

--- a/pao/duality/tests/test_linear_dual.py
+++ b/pao/duality/tests/test_linear_dual.py
@@ -20,9 +20,10 @@ try:
 except ImportError:
     yaml_available=False
 
-import pyutilib.misc
-from pyutilib.misc import Options, Container
-import pyutilib.th as unittest
+import pyomo.common.collections
+from pyomo.common.collections import Options, Container
+import pyomo.common.unittest as unittest
+from pyomo.common.fileutils import import_file
 
 from pyomo.environ import TransformationFactory, SolverFactory, ComponentUID
 import pyomo.opt
@@ -45,7 +46,7 @@ class CommonTests(object):
             #
             # Import the model file to create the model
             #
-            usermodel = pyutilib.misc.import_file(_args[0], clear_cache=True)
+            usermodel = import_file(_args[0], clear_cache=True)
             instance = usermodel.model
             #
             # Collected local variables

--- a/pao/duality/tests/test_linear_dual.py
+++ b/pao/duality/tests/test_linear_dual.py
@@ -21,6 +21,7 @@ except ImportError:
     yaml_available=False
 
 import pyomo.common.collections
+from pyomo.common.collections import Bunch
 import pyomo.common.unittest as unittest
 from pyomo.common.fileutils import import_file
 

--- a/pao/duality/tests/test_linear_dual.py
+++ b/pao/duality/tests/test_linear_dual.py
@@ -21,7 +21,6 @@ except ImportError:
     yaml_available=False
 
 import pyomo.common.collections
-from pyomo.common.collections import Options, Container
 import pyomo.common.unittest as unittest
 from pyomo.common.fileutils import import_file
 

--- a/pao/mpr/repn.py
+++ b/pao/mpr/repn.py
@@ -5,7 +5,7 @@ import pprint
 import collections.abc
 from scipy.sparse import csr_matrix, dok_matrix
 import numpy as np
-from pyutilib.misc import Bunch
+from pyomo.common.collections import Bunch
 
 
 def _equal_nparray(Ux, U_coef, Lx, L_coef):

--- a/pao/mpr/solvers/fa.py
+++ b/pao/mpr/solvers/fa.py
@@ -4,7 +4,6 @@
 #
 import time
 import numpy as np
-import pyutilib
 import pyomo.environ as pe
 import pyomo.opt
 from pyomo.common.config import ConfigBlock, ConfigValue

--- a/pao/mpr/solvers/ld.py
+++ b/pao/mpr/solvers/ld.py
@@ -5,7 +5,6 @@
 #
 import time
 import numpy as np
-import pyutilib
 import pyomo.environ as pe
 import pyomo.opt
 

--- a/pao/mpr/solvers/mibs.py
+++ b/pao/mpr/solvers/mibs.py
@@ -11,7 +11,6 @@ import os
 import sys
 import time
 import numpy as np
-import pyutilib
 import pyomo.environ as pe
 import pyomo.opt
 from pyomo.common.config import ConfigBlock, ConfigValue

--- a/pao/mpr/solvers/pccg.py
+++ b/pao/mpr/solvers/pccg.py
@@ -1,20 +1,19 @@
 #
 # A solver for linear bilevel programs using
 # using projected column constraint generation
-# "A projection-based reformulation and decomposition algorithm for global optimization 
+# "A projection-based reformulation and decomposition algorithm for global optimization
 #  of a class of mixed integer bilevel linear programs" by Dajun Yue, Jiyao Gao, Bo Zeng, Fengqi You
 #
 # Adapted from an implementation by She'ifa Punla-Green at Sandia National Labs
 #
 #This algorithm seeks to solve the following bilevel MILP:
-#    min cR*xu + cZ*yu + dR*xl0 + dZ*yl0 
+#    min cR*xu + cZ*yu + dR*xl0 + dZ*yl0
 #    s.t. AR*xu + AZ*yu + BR*xl0 + BZ* yl0 <= r
 #     (xl0,yl0) in argmax {wR*xl+wZ*yl: PR*xl+PZ*yl<=s-QR*xu-QZ*yu}
 #
 import time
 import numpy as np
 from munch import Munch
-import pyutilib
 import pyomo.environ as pe
 import pyomo.opt
 from pyomo.common.config import ConfigBlock, ConfigValue

--- a/pao/mpr/solvers/reg.py
+++ b/pao/mpr/solvers/reg.py
@@ -4,7 +4,6 @@
 #
 import time
 import numpy as np
-import pyutilib
 import pyomo.environ as pe
 import pyomo.opt
 from pyomo.common.config import ConfigBlock, ConfigValue

--- a/pao/mpr/tests/test_convert.py
+++ b/pao/mpr/tests/test_convert.py
@@ -1,5 +1,5 @@
 import numpy as np
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 from pao.mpr import *
 from pao.mpr.convert_repn import convert_to_standard_form, convert_binaries_to_integers
 

--- a/pao/mpr/tests/test_linearize.py
+++ b/pao/mpr/tests/test_linearize.py
@@ -1,6 +1,6 @@
 import pprint
 import numpy as np
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 from pao.mpr import *
 from pao.mpr.convert_repn import linearize_bilinear_terms
 

--- a/pao/mpr/tests/test_repn.py
+++ b/pao/mpr/tests/test_repn.py
@@ -1,6 +1,6 @@
 import numpy as np
 import scipy.sparse
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 from pao.mpr import *
 from pao.mpr.repn import SimplifiedList, LinearLevelRepn, LevelVariable, LevelValues, LevelValueWrapper1, LevelValueWrapper2
 

--- a/pao/mpr/tests/test_solve.py
+++ b/pao/mpr/tests/test_solve.py
@@ -1,5 +1,5 @@
 import math
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 from pao.mpr import *
 from pao.mpr import examples
 import pyomo.opt

--- a/pao/pyomo/plugins/collect.py
+++ b/pao/pyomo/plugins/collect.py
@@ -16,7 +16,7 @@ This module defines the collect_bilevel_matrix_representation() function, which
 collects information that is used to in bilevel algorithm development.
 """
 
-from pyutilib.misc import Bunch
+from pyomo.common.collections import Bunch
 from pyomo.repn import generate_standard_repn
 from pyomo.core import (Var,
                         Constraint,

--- a/pao/pyomo/tests/attic/test_bilevel_dualize.py
+++ b/pao/pyomo/tests/attic/test_bilevel_dualize.py
@@ -14,7 +14,7 @@
 
 from os.path import abspath, dirname, join
 from parameterized import parameterized
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 
 from pyomo.environ import *
 from pao.pyomo.components import SubModel

--- a/pao/pyomo/tests/attic/test_bilevel_matrix_repn.py
+++ b/pao/pyomo/tests/attic/test_bilevel_matrix_repn.py
@@ -15,7 +15,7 @@
 from os.path import abspath, dirname, join
 import math
 from parameterized import parameterized
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 
 import pyomo.opt
 from pyomo.environ import *

--- a/pao/pyomo/tests/attic/test_highpoint.py
+++ b/pao/pyomo/tests/attic/test_highpoint.py
@@ -17,7 +17,7 @@ import math
 import pyomo.opt
 from os.path import abspath, dirname, join
 from parameterized import parameterized
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 import itertools
 from pyomo.environ import *
 

--- a/pao/pyomo/tests/attic/test_integer_bilevel.py
+++ b/pao/pyomo/tests/attic/test_integer_bilevel.py
@@ -15,7 +15,7 @@
 from os.path import abspath, dirname, join
 import math
 from parameterized import parameterized
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 
 import pyomo.opt
 from pyomo.environ import *

--- a/pao/pyomo/tests/attic/test_linear_bilevel.py
+++ b/pao/pyomo/tests/attic/test_linear_bilevel.py
@@ -15,7 +15,7 @@
 from os.path import abspath, dirname, join
 import math
 from parameterized import parameterized
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 
 import pyomo.opt
 from pyomo.environ import *

--- a/pao/pyomo/tests/attic/test_linear_dual.py.old
+++ b/pao/pyomo/tests/attic/test_linear_dual.py.old
@@ -17,7 +17,7 @@ from os.path import abspath, dirname, normpath, join
 currdir = dirname(abspath(__file__))
 exdir = currdir #normpath(join(currdir,'..','..','..','examples','bilevel'))
 
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 
 import pyomo.opt
 import pyomo.scripting.pyomo_main as pyomo_main

--- a/pao/pyomo/tests/attic/test_linear_stochastic_interdiction.py
+++ b/pao/pyomo/tests/attic/test_linear_stochastic_interdiction.py
@@ -15,7 +15,7 @@
 from os.path import abspath, dirname, join
 import math
 from parameterized import parameterized
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 
 import pyomo.opt
 from pyomo.environ import *

--- a/pao/pyomo/tests/attic/test_xfrm.py.old
+++ b/pao/pyomo/tests/attic/test_xfrm.py.old
@@ -12,7 +12,7 @@
 # Test transformations for linear duality
 #
 
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 from pyomo.environ import *
 import pao
 

--- a/pao/pyomo/tests/test_convert.py
+++ b/pao/pyomo/tests/test_convert.py
@@ -1,5 +1,5 @@
 import numpy as np
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 import pyomo.environ as pe
 from pao.pyomo.convert import collect_multilevel_tree, convert_pyomo2LinearMultilevelProblem, convert_pyomo2MultilevelProblem
 from pao.pyomo import SubModel

--- a/pao/pyomo/tests/test_mpr.py
+++ b/pao/pyomo/tests/test_mpr.py
@@ -1,5 +1,5 @@
 import math
-import pyutilib.th as unittest
+import pyomo.common.unittest as unittest
 from pao.pyomo import *
 from pao.pyomo import examples
 import pyomo.opt


### PR DESCRIPTION
Pyomo has dropped the dependence of pyutilib (https://github.com/Pyomo/pyomo/blob/main/CHANGELOG.md?plain=1#L720).
This PR aims to remove the dependence of pyutilib in pao, which might help resolve the issue #98 
@mkoeppe