### PR TITLE
Work with the changes in the output format of MibS and add test examples for MibS solver

### DIFF
--- a/pao/mpr/examples/__init__.py
+++ b/pao/mpr/examples/__init__.py
@@ -8,6 +8,8 @@ from . import besancon27
 from . import besancon27_shifted
 from . import getachew_ex1
 from . import getachew_ex2
+from . import mibs
+from . import moore
 from . import pineda
 from . import toyexample1
 from . import toyexample2

--- a/pao/mpr/solvers/mibs.py
+++ b/pao/mpr/solvers/mibs.py
@@ -233,7 +233,7 @@ class LinearMultilevelSolver_MIBS(LinearMultilevelSolverBase):
                 OUTPUT.write("OS 1\n")
             else:
                 OUTPUT.write("OS -1\n")
-        
+
         return M
 
 pao.common.SolverAPI._generate_solve_docstring(LinearMultilevelSolver_MIBS)

--- a/pao/mpr/tests/test_solve.py
+++ b/pao/mpr/tests/test_solve.py
@@ -325,11 +325,8 @@ class Test_bilevel_MIBS(unittest.TestCase):
         mpr.check()
 
         opt = Solver('pao.mpr.MIBS')
-        try:
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
             opt.solve(mpr)
-            self.fail("Expected an error: linking variables should be integer")
-        except RuntimeError as err:
-            print("Solver run-time error:", err)
 
         # self.assertTrue(math.isclose(mpr.U.x.values[0], 4, abs_tol=1e-4))
         # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 4, abs_tol=1e-4))
@@ -339,11 +336,8 @@ class Test_bilevel_MIBS(unittest.TestCase):
         mpr.check()
 
         opt = Solver('pao.mpr.MIBS')
-        try:
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
             opt.solve(mpr)
-            self.fail("Expected an error: linking variables should be integer")
-        except RuntimeError as err:
-            print("Solver run-time error:", err)
 
         # self.assertTrue(math.isclose(mpr.U.x.values[0], 4, abs_tol=1e-4))
         # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 4, abs_tol=1e-4))
@@ -373,11 +367,8 @@ class Test_bilevel_MIBS(unittest.TestCase):
         mpr.check()
 
         opt = Solver('pao.mpr.MIBS')
-        try:
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
             opt.solve(mpr)
-            self.fail("Expected an error: linking variables should be integer")
-        except RuntimeError as err:
-            print("Solver run-time error:", err)
 
         # self.assertTrue(math.isclose(mpr.U.x.values[0], 0, abs_tol=1e-4))
         # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 1, abs_tol=1e-4))
@@ -387,11 +378,8 @@ class Test_bilevel_MIBS(unittest.TestCase):
         mpr.check()
 
         opt = Solver('pao.mpr.MIBS')
-        try:
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
             opt.solve(mpr)
-            self.fail("Expected an error: linking variables should be integer")
-        except RuntimeError as err:
-            print("Solver run-time error:", err)
 
         # self.assertTrue(math.isclose(mpr.U.x.values[0], 2.5, abs_tol=1e-4))
         # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 1.25, abs_tol=1e-4))
@@ -401,11 +389,8 @@ class Test_bilevel_MIBS(unittest.TestCase):
         mpr.check()
 
         opt = Solver('pao.mpr.MIBS')
-        try:
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
             opt.solve(mpr)
-            self.fail("Expected an error: linking variables should be integer")
-        except RuntimeError as err:
-            print("Solver run-time error:", err)
 
         # self.assertTrue(math.isclose(mpr.U.x.values[0], 8, abs_tol=1e-4))
         # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 6, abs_tol=1e-4))
@@ -415,11 +400,8 @@ class Test_bilevel_MIBS(unittest.TestCase):
         mpr.check()
 
         opt = Solver('pao.mpr.MIBS')
-        try:
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
             opt.solve(mpr)
-            self.fail("Expected an error: linking variables should be integer")
-        except RuntimeError as err:
-            print("Solver run-time error:", err)
 
         # self.assertTrue(math.isclose(mpr.U.x.values[0], 6, abs_tol=1e-4))
         # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 8, abs_tol=1e-4))
@@ -449,11 +431,8 @@ class Test_bilevel_MIBS(unittest.TestCase):
         mpr.check()
 
         opt = Solver('pao.mpr.MIBS')
-        try:
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
             opt.solve(mpr)
-            self.fail("Expected an error: linking variables should be integer")
-        except RuntimeError as err:
-            print("Solver run-time error:", err)
 
         # self.assertTrue(math.isclose(mpr.U.x.values[0], 2, abs_tol=1e-4))
         # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 100, abs_tol=1e-4))
@@ -484,11 +463,8 @@ class Test_bilevel_MIBS(unittest.TestCase):
 
         opt = Solver('pao.mpr.MIBS')
 
-        try:
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
             opt.solve(mpr)
-            self.fail("Expected an error: linking variables should be integer")
-        except RuntimeError as err:
-            print("Solver run-time error:", err)
 
         # self.assertTrue(math.isclose(mpr.U.x.values[0], 3, abs_tol=1e-4))
         # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 0.5, abs_tol=1e-4))

--- a/pao/mpr/tests/test_solve.py
+++ b/pao/mpr/tests/test_solve.py
@@ -5,7 +5,7 @@ from pao.mpr import examples
 import pyomo.opt
 
 
-solvers = pyomo.opt.check_available_solvers('glpk','cbc','ipopt')
+solvers = pyomo.opt.check_available_solvers('glpk','cbc','ipopt','mibs')
 
 
 class Test_bilevel_FA(unittest.TestCase):
@@ -43,7 +43,7 @@ class Test_bilevel_FA(unittest.TestCase):
         except AssertionError:
             pass
 
-        lmp, soln = linearize_bilinear_terms(qmp, 1e6) 
+        lmp, soln = linearize_bilinear_terms(qmp, 1e6)
         lmp.check()
         opt.solve(lmp)
         soln.copy(From=lmp, To=qmp)
@@ -225,7 +225,7 @@ class Test_bilevel_PCCG(unittest.TestCase):
         except AssertionError:
             pass
 
-        lmp, soln = linearize_bilinear_terms(qmp, 1e6) 
+        lmp, soln = linearize_bilinear_terms(qmp, 1e6)
         lmp.check()
         opt.solve(lmp)
         soln.copy(From=lmp, To=qmp)
@@ -315,6 +315,185 @@ class Test_bilevel_PCCG(unittest.TestCase):
         self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 0.5, abs_tol=1e-4))
         self.assertEqual(mpr.U.x.values[1], 8)
         self.assertEqual(mpr.U.LL.x.values[1], 0)
+
+
+@unittest.skipIf('mibs' not in solvers, "MibS solver is not available")
+class Test_bilevel_MIBS(unittest.TestCase):
+
+    def test_bard511(self):
+        mpr = examples.bard511.create()
+        mpr.check()
+
+        opt = Solver('pao.mpr.MIBS')
+        try:
+            opt.solve(mpr)
+            self.fail("Expected an error: linking variables should be integer")
+        except RuntimeError as err:
+            print("Solver run-time error:", err)
+
+        # self.assertTrue(math.isclose(mpr.U.x.values[0], 4, abs_tol=1e-4))
+        # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 4, abs_tol=1e-4))
+
+    def test_bard511_list(self):
+        mpr = examples.bard511_list.create()
+        mpr.check()
+
+        opt = Solver('pao.mpr.MIBS')
+        try:
+            opt.solve(mpr)
+            self.fail("Expected an error: linking variables should be integer")
+        except RuntimeError as err:
+            print("Solver run-time error:", err)
+
+        # self.assertTrue(math.isclose(mpr.U.x.values[0], 4, abs_tol=1e-4))
+        # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 4, abs_tol=1e-4))
+
+    def test_barguel(self):
+        qmp = examples.barguel.create()
+        qmp.check()
+
+        opt = Solver('pao.mpr.MIBS')
+        try:
+            opt.solve(qmp)
+            self.fail("Expected an assertion error")
+        except AssertionError:
+            pass
+
+        lmp, soln = linearize_bilinear_terms(qmp, 1e6)
+        lmp.check()
+        opt.solve(lmp)
+        soln.copy(From=lmp, To=qmp)
+
+        self.assertTrue(math.isclose(qmp.U.x.values[0], 0))
+        self.assertTrue(math.isclose(qmp.U.LL.x.values[0], 0))
+        self.assertTrue(math.isclose(qmp.U.LL.x.values[1], 0))
+
+    def test_besancon27(self):
+        mpr = examples.besancon27.create()
+        mpr.check()
+
+        opt = Solver('pao.mpr.MIBS')
+        try:
+            opt.solve(mpr)
+            self.fail("Expected an error: linking variables should be integer")
+        except RuntimeError as err:
+            print("Solver run-time error:", err)
+
+        # self.assertTrue(math.isclose(mpr.U.x.values[0], 0, abs_tol=1e-4))
+        # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 1, abs_tol=1e-4))
+
+    def test_besancon27_shifted(self):
+        mpr = examples.besancon27_shifted.create()
+        mpr.check()
+
+        opt = Solver('pao.mpr.MIBS')
+        try:
+            opt.solve(mpr)
+            self.fail("Expected an error: linking variables should be integer")
+        except RuntimeError as err:
+            print("Solver run-time error:", err)
+
+        # self.assertTrue(math.isclose(mpr.U.x.values[0], 2.5, abs_tol=1e-4))
+        # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 1.25, abs_tol=1e-4))
+
+    def test_getachew_ex1(self):
+        mpr = examples.getachew_ex1.create()
+        mpr.check()
+
+        opt = Solver('pao.mpr.MIBS')
+        try:
+            opt.solve(mpr)
+            self.fail("Expected an error: linking variables should be integer")
+        except RuntimeError as err:
+            print("Solver run-time error:", err)
+
+        # self.assertTrue(math.isclose(mpr.U.x.values[0], 8, abs_tol=1e-4))
+        # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 6, abs_tol=1e-4))
+
+    def test_getachew_ex2(self):
+        mpr = examples.getachew_ex2.create()
+        mpr.check()
+
+        opt = Solver('pao.mpr.MIBS')
+        try:
+            opt.solve(mpr)
+            self.fail("Expected an error: linking variables should be integer")
+        except RuntimeError as err:
+            print("Solver run-time error:", err)
+
+        # self.assertTrue(math.isclose(mpr.U.x.values[0], 6, abs_tol=1e-4))
+        # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 8, abs_tol=1e-4))
+
+    def test_mibs(self):
+        mpr = examples.mibs.create()
+        mpr.check()
+
+        opt = Solver('pao.mpr.MIBS')
+        opt.solve(mpr)
+
+        self.assertTrue(math.isclose(mpr.U.x.values[0], 6, abs_tol=1e-4))
+        self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 5, abs_tol=1e-4))
+
+    def test_moore(self):
+        mpr = examples.moore.create()
+        mpr.check()
+
+        opt = Solver('pao.mpr.MIBS')
+        opt.solve(mpr)
+
+        self.assertTrue(math.isclose(mpr.U.x.values[0], 2, abs_tol=1e-4))
+        self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 2, abs_tol=1e-4))
+
+    def test_pineda(self):
+        mpr = examples.pineda.create()
+        mpr.check()
+
+        opt = Solver('pao.mpr.MIBS')
+        try:
+            opt.solve(mpr)
+            self.fail("Expected an error: linking variables should be integer")
+        except RuntimeError as err:
+            print("Solver run-time error:", err)
+
+        # self.assertTrue(math.isclose(mpr.U.x.values[0], 2, abs_tol=1e-4))
+        # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 100, abs_tol=1e-4))
+
+    def test_toyexample1(self):
+        mpr = examples.toyexample1.create()
+        mpr.check()
+
+        opt = Solver('pao.mpr.MIBS')
+        opt.solve(mpr)
+
+        self.assertEqual(mpr.U.x.values[0], 2)
+        self.assertEqual(mpr.U.LL.x.values[0], 2)
+
+    def test_toyexample2(self):
+        mpr = examples.toyexample2.create()
+        mpr.check()
+
+        opt = Solver('pao.mpr.MIBS')
+        opt.solve(mpr)
+
+        self.assertEqual(mpr.U.x.values[0], 8)
+        self.assertEqual(mpr.U.LL.x.values[0], 6)
+
+    def test_toyexample3(self):
+        mpr = examples.toyexample3.create()
+        mpr.check()
+
+        opt = Solver('pao.mpr.MIBS')
+
+        try:
+            opt.solve(mpr)
+            self.fail("Expected an error: linking variables should be integer")
+        except RuntimeError as err:
+            print("Solver run-time error:", err)
+
+        # self.assertTrue(math.isclose(mpr.U.x.values[0], 3, abs_tol=1e-4))
+        # self.assertTrue(math.isclose(mpr.U.LL.x.values[0], 0.5, abs_tol=1e-4))
+        # self.assertEqual(mpr.U.x.values[1], 8)
+        # self.assertEqual(mpr.U.LL.x.values[1], 0)
 
 
 #class Test_bilevel_ld(unittest.TestCase):

--- a/pao/pyomo/examples/__init__.py
+++ b/pao/pyomo/examples/__init__.py
@@ -5,6 +5,8 @@ from . import barguel
 from . import besancon27
 from . import getachew_ex1
 from . import getachew_ex2
+from . import mibs
+from . import moore
 from . import pineda
 from . import sip_example1
 from . import toyexample1

--- a/pao/pyomo/tests/test_mpr.py
+++ b/pao/pyomo/tests/test_mpr.py
@@ -5,7 +5,7 @@ from pao.pyomo import examples
 import pyomo.opt
 
 
-solvers = pyomo.opt.check_available_solvers('glpk','cbc','ipopt','gurobi')
+solvers = pyomo.opt.check_available_solvers('glpk','cbc','ipopt','gurobi', 'mibs')
 
 
 class Test_solver(unittest.TestCase):
@@ -257,6 +257,105 @@ class Test_pyomo_PCCG(unittest.TestCase):
         self.assertTrue(math.isclose(M.L.xR.value, 0.5, abs_tol=1e-4))
         self.assertEqual(M.xZ.value, 8)
         self.assertEqual(M.L.xZ.value, 0)
+
+
+@unittest.skipIf('mibs' not in solvers, "MibS solver is not available")
+class Test_bilevel_MIBS(unittest.TestCase):
+
+    def test_bard511(self):
+        M = examples.bard511.create()
+
+        opt = Solver('pao.pyomo.MIBS')
+
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
+            opt.solve(M)
+
+    def test_barguel(self):
+        M = examples.barguel.create()
+
+        opt = Solver('pao.pyomo.MIBS')
+        try:
+            opt.solve(M)
+            self.fail("Expected an assertion error")
+        except AssertionError:
+            pass
+
+        opt.solve(M, linearize_bigm=1e6)
+
+        self.assertTrue(math.isclose(M.u.value, 0))
+        self.assertTrue(math.isclose(M.x.value, 0))
+        self.assertTrue(math.isclose(M.y.value, 0))
+
+    def test_besancon27(self):
+        M = examples.besancon27.create()
+
+        opt = Solver('pao.pyomo.MIBS')
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
+            opt.solve(M)
+
+    def test_getachew_ex1(self):
+        M = examples.getachew_ex1.create()
+
+        opt = Solver('pao.pyomo.MIBS')
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
+            opt.solve(M)
+
+    def test_getachew_ex2(self):
+        M = examples.getachew_ex2.create()
+
+        opt = Solver('pao.pyomo.MIBS')
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
+            opt.solve(M)
+
+    def test_mibs(self):
+        M = examples.mibs.create()
+
+        opt = Solver('pao.pyomo.MIBS')
+        opt.solve(M)
+
+        self.assertTrue(math.isclose(M.x.value, 6, abs_tol=1e-4))
+        self.assertTrue(math.isclose(M.y.value, 5, abs_tol=1e-4))
+
+    def test_moore(self):
+        M = examples.moore.create()
+
+        opt = Solver('pao.pyomo.MIBS')
+        opt.solve(M)
+
+        self.assertEqual(M.xZ.value, 2)
+        self.assertEqual(M.L.xZ.value, 2)
+
+    def test_pineda(self):
+        M = examples.pineda.create()
+
+        opt = Solver('pao.pyomo.MIBS')
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
+            opt.solve(M)
+
+    def test_toyexample1(self):
+        M = examples.toyexample1.create()
+
+        opt = Solver('pao.pyomo.MIBS')
+        opt.solve(M)
+
+        self.assertEqual(M.xZ.value, 2)
+        self.assertEqual(M.L.xZ.value, 2)
+
+    def test_toyexample2(self):
+        M = examples.toyexample2.create()
+
+        opt = Solver('pao.pyomo.MIBS')
+        opt.solve(M)
+
+        self.assertEqual(M.xZ.value, 8)
+        self.assertEqual(M.L.xZ.value, 6)
+
+    def test_toyexample3(self):
+        M = examples.toyexample3.create()
+
+        opt = Solver('pao.pyomo.MIBS')
+        with self.assertRaisesRegex(RuntimeError, "ERROR:All linking variables should be integer"):
+            opt.solve(M)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR tries to make PAO work with MibS as pointed out in #98.
And raise the error if the linking variables are not integer: "ERROR:All linking variables should be integer"
@mkoeppe